### PR TITLE
Update network_backup.yml

### DIFF
--- a/network_backup.yml
+++ b/network_backup.yml
@@ -65,3 +65,4 @@
         tower_username: admin
         tower_password: ansible
         tower_host: "https://{{ansible_fqdn}}"
+        validate_certs: no


### PR DESCRIPTION
Please review. Students were receiving an error during the final task. The error was related to insecure TLS, invalid certs. Disabling ssl verification will help ensure this doesnt happen in most cases.