### PR TITLE
Renamed copy tasks

### DIFF
--- a/roles/build_report/tasks/main.yml
+++ b/roles/build_report/tasks/main.yml
@@ -31,14 +31,14 @@
     src: report.j2
     dest: "{{ file_path }}/index.html"
 
-- name: copy CSS over
+- name: copy CSS directory over
   become: true
   copy:
     src: "css"
     dest: "{{ file_path }}"
     directory_mode: true
 
-- name: copy CSS over
+- name: copy several files over
   become: true
   copy:
     src: "{{ item }}"


### PR DESCRIPTION
Renamed two tasks (copy module) that were named identically. Improved description to reflect what files/directories are copied