### PR TITLE
Adding defaults for user and mgmt IP in ansible.j2

### DIFF
--- a/roles/build_report/templates/ansible.j2
+++ b/roles/build_report/templates/ansible.j2
@@ -7,7 +7,7 @@
 <tbody>
   <tr>
     <td>Ansible user</td>
-    <td class="sub_net_info">{{ hostvars[network_switch]['ansible_user'] }}</td>
+    <td class="sub_net_info">{{ hostvars[network_switch]['ansible_user'] | default("Unknown") }}</td>
   </tr>
   <tr>
     <td>Transport</td>
@@ -15,7 +15,7 @@
   </tr>
   <tr>
     <td>Ansible Mgmt IP</td>
-    <td class="sub_net_info">{{ hostvars[network_switch]['ansible_host'] }}</td>
+    <td class="sub_net_info">{{ hostvars[network_switch]['ansible_host']|default("Unknown") }}</td>
   </tr>
   <tr>
     <td>Ansible groups</td>


### PR DESCRIPTION
Inside the ansible.j2 template under the build_report role, there are twice references to ansible_host and ansible_user, which do not have default values if those values are not defined. This could've also been addressed other ways, such as an "if" statement, but a jinja default filter was used to stay in alignment with other sections in the template.