### PR TITLE
fix: allow ssh-rsa for Cisco devices via libssh config

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,3 +3,5 @@ host_key_checking = False
 retry_files_enabled = False
 no_target_syslog = False
 env = PYTHONWARNINGS=ignore::FutureWarning
+[libssh_connection]
+publickey_algorithms = ssh-rsa


### PR DESCRIPTION
## Summary

- Newer `ansible-pylibssh` versions reject `ssh-rsa` by default via `PUBLICKEY_ACCEPTED_TYPES`
- Cisco IOS-XE/C8K devices require `ssh-rsa` for public key authentication
- Added `[libssh_connection] publickey_algorithms = ssh-rsa` to the project `ansible.cfg`
- This is the project-level config that AAP picks up when running job templates (Network Report, Backup, etc.)

## Test plan

- [ ] Run Network Report job template from AAP -- rtr1 (Cisco) should succeed
- [ ] Run Backup job template from AAP -- rtr1 should back up successfully

Made with [Cursor](https://cursor.com)