### PR TITLE
fix: run iOS restore scp from EE using fetched /tmp backup

### DIFF
--- a/roles/restore/tasks/ios/overwrite.yml
+++ b/roles/restore/tasks/ios/overwrite.yml
@@ -5,37 +5,35 @@
       - ip scp server enable
 
 ### -O forces scp versus sftp which Cisco IOS does support
-### Tries sshpass when ansible_password is set; rescues to plain scp for
-### SSH-key environments or when sshpass is unavailable on the control node.
+### SCP runs from the execution environment using the fetched backup in /tmp
+### (same as merge restore). Tries sshpass when ansible_password is set;
+### rescues to key-based scp with BatchMode so it fails fast instead of hanging.
 - name: Copy file over to flash on network device using SCP
   vars:
+    _scp_host: "{{ ansible_host | default(inventory_hostname) }}"
     _scp_user: "{{ ansible_user + '@' if ansible_user is defined else '' }}"
-    _scp_src: "/backup/{{ rollback_date }}/{{ inventory_hostname }}.txt"
-    _scp_dest: "{{ _scp_user }}{{ inventory_hostname }}:'flash:{{ rollback_date }}-{{ inventory_hostname }}.txt'"
+    _scp_src: "/tmp/{{ rollback_date }}/{{ inventory_hostname }}.txt"
+    _scp_dest: "{{ _scp_user }}{{ _scp_host }}:'flash:{{ rollback_date }}-{{ inventory_hostname }}.txt'"
   block:
     - name: Copy file over to flash using SCP (password auth via sshpass)
       ansible.builtin.shell: >
         sshpass -p "{{ ansible_password }}" scp -O -o StrictHostKeyChecking=no
         {{ _scp_src }} {{ _scp_dest }}
-      run_once: true
-      delegate_to: backup-server
   rescue:
     - name: Copy file over to flash using SCP (SSH key auth)
       ansible.builtin.shell: >
-        scp -O -o StrictHostKeyChecking=no {{ _scp_src }} {{ _scp_dest }}
-      run_once: true
-      delegate_to: backup-server
+        scp -O -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=30
+        {{ _scp_src }} {{ _scp_dest }}
   when: ansible_password | default('') | length > 0
 
 - name: Copy file over to flash on network device using SCP (SSH key auth)
   vars:
+    _scp_host: "{{ ansible_host | default(inventory_hostname) }}"
     _scp_user: "{{ ansible_user + '@' if ansible_user is defined else '' }}"
   ansible.builtin.shell: >
-    scp -O -o StrictHostKeyChecking=no
-    /backup/{{ rollback_date }}/{{ inventory_hostname }}.txt
-    {{ _scp_user }}{{ inventory_hostname }}:'flash:{{ rollback_date }}-{{ inventory_hostname }}.txt'
-  run_once: true
-  delegate_to: backup-server
+    scp -O -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=30
+    /tmp/{{ rollback_date }}/{{ inventory_hostname }}.txt
+    {{ _scp_user }}{{ _scp_host }}:'flash:{{ rollback_date }}-{{ inventory_hostname }}.txt'
   when: ansible_password | default('') | length == 0
 
 - name: Overwrite startup config - overwrite


### PR DESCRIPTION
## Summary
- Run SCP from the execution environment (not backup-server) using the config already fetched to `/tmp`
- Target `ansible_host` instead of inventory hostname
- Add `BatchMode=yes` and `ConnectTimeout=30` on key-auth fallback so it fails fast instead of hanging on a password prompt

## Test plan
- [ ] Restore overwrite in lab with password auth + sshpass in EE
- [ ] Restore overwrite in lab where backup-server lacks sshpass/keys (should no longer hang)

Made with [Cursor](https://cursor.com)