### PR TITLE
fix: pass ansible_port and SSH key into iOS restore SCP

### DIFF
--- a/roles/restore/tasks/ios/overwrite.yml
+++ b/roles/restore/tasks/ios/overwrite.yml
@@ -11,6 +11,8 @@
   vars:
     _scp_host: "{{ ansible_host | default(inventory_hostname) }}"
     _scp_user: "{{ ansible_user + '@' if ansible_user is defined else '' }}"
+    _scp_port: "{{ '-P ' + (ansible_port | string) if ansible_port is defined else '' }}"
+    _scp_key: "{{ '-i ' + ansible_ssh_private_key_file if ansible_ssh_private_key_file is defined else '' }}"
     _scp_src: "/tmp/{{ rollback_date }}/{{ inventory_hostname }}.txt"
     _scp_dest: "{{ _scp_user }}{{ _scp_host }}:'flash:{{ rollback_date }}-{{ inventory_hostname }}.txt'"
   block:
@@ -21,8 +23,8 @@
         else
           _scp_o="-O"
         fi
-        sshpass -p "{{ ansible_password }}" scp $_scp_o -o StrictHostKeyChecking=no \
-          {{ _scp_src }} {{ _scp_dest }}
+        sshpass -p "{{ ansible_password }}" scp $_scp_o {{ _scp_port }} {{ _scp_key }} \
+          -o StrictHostKeyChecking=no {{ _scp_src }} {{ _scp_dest }}
   rescue:
     - name: Copy file over to flash using SCP (SSH key auth)
       ansible.builtin.shell: |
@@ -31,21 +33,24 @@
         else
           _scp_o="-O"
         fi
-        scp $_scp_o -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=30 \
-          {{ _scp_src }} {{ _scp_dest }}
+        scp $_scp_o {{ _scp_port }} {{ _scp_key }} -o StrictHostKeyChecking=no \
+          -o BatchMode=yes -o ConnectTimeout=30 {{ _scp_src }} {{ _scp_dest }}
   when: ansible_password | default('') | length > 0
 
 - name: Copy file over to flash on network device using SCP (SSH key auth)
   vars:
     _scp_host: "{{ ansible_host | default(inventory_hostname) }}"
     _scp_user: "{{ ansible_user + '@' if ansible_user is defined else '' }}"
+    _scp_port: "{{ '-P ' + (ansible_port | string) if ansible_port is defined else '' }}"
+    _scp_key: "{{ '-i ' + ansible_ssh_private_key_file if ansible_ssh_private_key_file is defined else '' }}"
   ansible.builtin.shell: |
     if scp -O 2>&1 | grep -q 'unknown option'; then
       _scp_o=""
     else
       _scp_o="-O"
     fi
-    scp $_scp_o -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=30 \
+    scp $_scp_o {{ _scp_port }} {{ _scp_key }} -o StrictHostKeyChecking=no \
+      -o BatchMode=yes -o ConnectTimeout=30 \
       /tmp/{{ rollback_date }}/{{ inventory_hostname }}.txt \
       {{ _scp_user }}{{ _scp_host }}:'flash:{{ rollback_date }}-{{ inventory_hostname }}.txt'
   when: ansible_password | default('') | length == 0


### PR DESCRIPTION
## Summary
- Pass `ansible_port` into the raw `scp` command used by iOS overwrite restore
- Pass `ansible_ssh_private_key_file` when key-based auth is used
- Fixes restore failures in containerlab (and similar) environments where multiple devices share `ansible_host` and rely on per-device ports

## Problem
Backup and network_cli tasks connect using `ansible_host` + `ansible_port`, but the iOS restore SCP step only used `ansible_host`, defaulting to port 22. In containerlab, that hit the wrong SSH service and failed with `Permission denied`.

## Test plan
- [x] Identified failure in AAP restore job for rtr1 (`ansible_host: containerlab`, `ansible_port: 2222`)
- [ ] Sync project in AAP from upstream after merge
- [ ] Re-run Network Automation - Restore and confirm SCP cmd includes `-P 2222`
- [ ] Verify rtr1 overwrite restore completes successfully


Made with [Cursor](https://cursor.com)