### PR TITLE
chore: ansible-lint fixes for iOS restore SCP tasks

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,5 +3,7 @@ host_key_checking = False
 retry_files_enabled = False
 no_target_syslog = False
 env = PYTHONWARNINGS=ignore::FutureWarning
+collections_scan_sys_path = false
+collections_path = ~/.ansible/collections:/usr/share/ansible/collections
 [libssh_connection]
 publickey_algorithms = ssh-rsa

--- a/roles/restore/tasks/ios/overwrite.yml
+++ b/roles/restore/tasks/ios/overwrite.yml
@@ -15,9 +15,11 @@
     _scp_key: "{{ '-i ' + ansible_ssh_private_key_file if ansible_ssh_private_key_file is defined else '' }}"
     _scp_src: "/tmp/{{ rollback_date }}/{{ inventory_hostname }}.txt"
     _scp_dest: "{{ _scp_user }}{{ _scp_host }}:'flash:{{ rollback_date }}-{{ inventory_hostname }}.txt'"
+  when: ansible_password | default('') | length > 0
   block:
     - name: Copy file over to flash using SCP (password auth via sshpass)
       ansible.builtin.shell: |
+        set -o pipefail
         if scp -O 2>&1 | grep -q 'unknown option'; then
           _scp_o=""
         else
@@ -25,9 +27,11 @@
         fi
         sshpass -p "{{ ansible_password }}" scp $_scp_o {{ _scp_port }} {{ _scp_key }} \
           -o StrictHostKeyChecking=no {{ _scp_src }} {{ _scp_dest }}
+      changed_when: true
   rescue:
     - name: Copy file over to flash using SCP (SSH key auth)
       ansible.builtin.shell: |
+        set -o pipefail
         if scp -O 2>&1 | grep -q 'unknown option'; then
           _scp_o=""
         else
@@ -35,7 +39,7 @@
         fi
         scp $_scp_o {{ _scp_port }} {{ _scp_key }} -o StrictHostKeyChecking=no \
           -o BatchMode=yes -o ConnectTimeout=30 {{ _scp_src }} {{ _scp_dest }}
-  when: ansible_password | default('') | length > 0
+      changed_when: true
 
 - name: Copy file over to flash on network device using SCP (SSH key auth)
   vars:
@@ -44,6 +48,7 @@
     _scp_port: "{{ '-P ' + (ansible_port | string) if ansible_port is defined else '' }}"
     _scp_key: "{{ '-i ' + ansible_ssh_private_key_file if ansible_ssh_private_key_file is defined else '' }}"
   ansible.builtin.shell: |
+    set -o pipefail
     if scp -O 2>&1 | grep -q 'unknown option'; then
       _scp_o=""
     else
@@ -53,6 +58,7 @@
       -o BatchMode=yes -o ConnectTimeout=30 \
       /tmp/{{ rollback_date }}/{{ inventory_hostname }}.txt \
       {{ _scp_user }}{{ _scp_host }}:'flash:{{ rollback_date }}-{{ inventory_hostname }}.txt'
+  changed_when: true
   when: ansible_password | default('') | length == 0
 
 - name: Overwrite startup config - overwrite


### PR DESCRIPTION
## Summary
- Add `set -o pipefail` and `changed_when: true` to iOS restore SCP shell tasks (ansible-lint)
- Reorder task keys (`when` before `block`)
- Set `collections_scan_sys_path = false` in `ansible.cfg` to suppress duplicate collection warnings

No functional SCP logic changes beyond what was merged in PR #77.

## Test plan
- [ ] Sync project in AAP
- [ ] Run Network Automation - Restore with `limit: rtr1`
- [ ] Confirm SCP step includes `-P 2222` and restore completes


Made with [Cursor](https://cursor.com)